### PR TITLE
Update synthetics deprecated runtime version

### DIFF
--- a/ZonalShiftExample/ARC-Zonal-Shift-Demo.json
+++ b/ZonalShiftExample/ARC-Zonal-Shift-Demo.json
@@ -704,7 +704,7 @@
             "Arn"
           ]
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
+        "RuntimeVersion": "syn-nodejs-puppeteer-6.1",
         "RunConfig": {
           "TimeoutInSeconds": 45
         },
@@ -782,7 +782,7 @@
             "Arn"
           ]
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
+        "RuntimeVersion": "syn-nodejs-puppeteer-6.1",
         "RunConfig": {
           "TimeoutInSeconds": 45
         },
@@ -860,7 +860,7 @@
             "Arn"
           ]
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
+        "RuntimeVersion": "syn-nodejs-puppeteer-6.1",
         "RunConfig": {
           "TimeoutInSeconds": 45
         },
@@ -938,7 +938,7 @@
             "Arn"
           ]
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
+        "RuntimeVersion": "syn-nodejs-puppeteer-6.1",
         "RunConfig": {
           "TimeoutInSeconds": 45
         },


### PR DESCRIPTION
*Issue:*
https://github.com/aws-samples/arc-zonal-shift-demo/issues/3

*Description:*
According to the [official document](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library.html#CloudWatch_Synthetics_Canaries_runtime_support), the current synthetics runtime version was deprecated on January 8, 2024.

*Motivation and Context:*
To fix the issue, I've updated the synthetics runtime version.

*Breaking Changes:*
No

*How Has This Been Tested?*
- [x] I have created stack successfully on my AWS account, eu-west-1 region, on my pull request.